### PR TITLE
Overlap AllReduce

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ apex/
 
 # tmp files
 *.swp
+examples_deepspeed/MoE/output
 
 # AML workspace config file
 config.json

--- a/examples_deepspeed/MoE/ds_pretrain_gpt_350M_MoE128.sh
+++ b/examples_deepspeed/MoE/ds_pretrain_gpt_350M_MoE128.sh
@@ -119,7 +119,7 @@ MP_SIZE=1
 ## Currently we don't support PP for MoE. To disable PP, set PP_SIZE
 ## to 1 and use the "--no-pipeline-parallel" arg.
 PP_SIZE=1
-NUM_GPUS=64
+NUM_GPUS=$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)
 ###############################################################################
 ### MoE configs
 ## Number of experts. EP_SIZE 1 means dense model without MoE
@@ -301,6 +301,7 @@ megatron_options=" \
         --log-timers-to-tensorboard \
         --log-batch-size-to-tensorboard \
         --log-validation-ppl-to-tensorboard \
+        --overlap-grad-reduce \
         --tensorboard-dir ${TENSORBOARD_DIR}"
 
 if [ "${ACTIVATION_CHECKPOINT}" = "true" ]; then

--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -183,6 +183,9 @@ def validate_args(args):
     if args.accumulate_allreduce_grads_in_fp32:
         assert args.DDP_impl == 'local'
         assert args.use_contiguous_buffers_in_local_ddp
+    if args.overlap_grad_reduce:
+        assert args.pipeline_model_parallel_size == 1, ('Overlapping grade reduce only supported without pipeline '
+                                                        'parallelism')
 
     # If we use the distributed optimizer, we need to have local DDP
     # and we should make sure use-contiguous-buffers-in-local-ddp is on.
@@ -1115,6 +1118,8 @@ def _add_distributed_args(parser):
                        choices=['local', 'torch', 'FSDP'],
                        help='which DistributedDataParallel implementation '
                        'to use.')
+    group.add_argument('--overlap-grad-reduce', action='store_true',
+                       default=False, help='If set, overlap DDP grad reduce')
     group.add_argument('--no-contiguous-buffers-in-local-ddp',
                        action='store_false', help='If set, dont use '
                        'contiguous buffer in local DDP.',


### PR DESCRIPTION
### About
This change syncs with recent work in overlapping AllReduce discussed [here ](https://github.com/NVIDIA/Megatron-LM/issues/391)and implemented [here](https://github.com/NVIDIA/Megatron-LM/commit/2d5220a424f7c52d597e06e47934d6467294a559).

### Changes
- Adds a command line switch `overlap-grad-reduce` for overlapping data-parallel AllReduce with compute
- Adds gradient buckets

### Context
This feature is needed for actualizing the scenario described in [Lina](https://www.usenix.org/conference/atc23/presentation/li-jiamin), as they observe network contention caused by concurrent AllReduce and AllToAll.