### PR TITLE
Deduplicate Auto-generated Requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,6 @@ matplotlib==3.7.3
 mmcv==2.1.0
 nltk==3.8.1
 numpy==1.24.4
-numpy==1.17.4
 nvtx==0.2.8
 packaging==23.2
 Pillow==10.0.1


### PR DESCRIPTION
Removes duplicate `numpy` requirement